### PR TITLE
Rough CMake build improvements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
+
+# the settings below will be automatically configured by the rest of this script
+
+project(PLANC CXX)
+set(PLANC_MAJOR_VERSION 0)
+set(PLANC_MINOR_VERSION 8)
+set(PLANC_PATCH_VERSION 1)
+set(PLANC_VERSION "${PLANC_MAJOR_VERSION}.${PLANC_MINOR_VERSION}.${PLANC_PATCH_VERSION}")
+
+# Adhere to GNU filesystem layout conventions
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+
+set(NMF_SOURCE_DIR ${PROJECT_SOURCE_DIR}/nmf)
+set(NTF_SOURCE_DIR ${PROJECT_SOURCE_DIR}/ntf)
+set(DISTNMF_SOURCE_DIR ${PROJECT_SOURCE_DIR}/nmf)
+set(DISTNTF_SOURCE_DIR ${PROJECT_SOURCE_DIR}/nmf)
+
+set(DENSEDIRS nmf distnmf distntf)
+set(SPARSEDIRS nmf distnmf)
+
+set(CMAKE_BUILD_SPARSE 0)
+foreach (DENSEDIR ${DENSEDIRS})
+  add_subdirectory(${DENSEDIR} dense_${DENSEDIR})
+endforeach()
+  
+set(CMAKE_BUILD_SPARSE 1)
+foreach (SPARSEDIR ${SPARSEDIRS})
+  add_subdirectory(${SPARSEDIR} sparse_${SPARSEDIR})
+endforeach()

--- a/distnmf/CMakeLists.txt
+++ b/distnmf/CMakeLists.txt
@@ -73,19 +73,26 @@ include_directories(
 add_definitions(-std=c++11 -w)
 
 if(CMAKE_WITH_PACOSS)
+  set(DENSE_OR_SPARSE sparse)
   add_executable(sparse_distnmf
     distnmf.cpp
   )
   target_link_libraries(sparse_distnmf ${NMFLIB_LIBS} pacoss)
 elseif(CMAKE_BUILD_SPARSE)
+  set(DENSE_OR_SPARSE sparse)
   add_executable(sparse_distnmf
     distnmf.cpp
   )
   target_link_libraries(sparse_distnmf ${NMFLIB_LIBS})
 else()
+  set(DENSE_OR_SPARSE dense)
   add_executable(dense_distnmf
     distnmf.cpp
   )
   target_link_libraries(dense_distnmf ${NMFLIB_LIBS})
 endif()
 
+install(TARGETS ${DENSE_OR_SPARSE}_distnmf
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )

--- a/distntf/CMakeLists.txt
+++ b/distntf/CMakeLists.txt
@@ -53,3 +53,7 @@ add_executable(dense_distntf
 )
 
 target_link_libraries(dense_distntf ${NMFLIB_LIBS})
+install(TARGETS dense_distntf
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )

--- a/nmf/CMakeLists.txt
+++ b/nmf/CMakeLists.txt
@@ -30,16 +30,16 @@ include_directories(
   ${MKL_INCLUDE_DIR}
   ${OPENBLAS_INCLUDE_DIR}
 )
+
 if(CMAKE_BUILD_SPARSE)
-  add_executable(sparse_nmf
-    nmf.cpp
-  )
-  target_link_libraries(sparse_nmf ${NMFLIB_LIBS})
+  set(DENSE_OR_SPARSE sparse)
 else()
-  add_executable(dense_nmf
-    nmf.cpp
-  )
-  target_link_libraries(dense_nmf ${NMFLIB_LIBS})
+  set(DENSE_OR_SPARSE dense)
 endif()
 
-
+add_executable(${DENSE_OR_SPARSE}_nmf nmf.cpp)
+target_link_libraries(${DENSE_OR_SPARSE}_nmf ${NMFLIB_LIBS})
+install(TARGETS ${DENSE_OR_SPARSE}_nmf
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )

--- a/ntf/CMakeLists.txt
+++ b/ntf/CMakeLists.txt
@@ -40,3 +40,7 @@ ntf.cpp
 )
 
 target_link_libraries(dense_ntf ${NTFLIB_LIBS} ${NMFLIB_LIBS})
+install(TARGETS dense_ntf
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )


### PR DESCRIPTION
A top-level `CMakeLists.txt` is a pre-requisite to allowing planc to be installable by [Spack](https://github.com/spack/spack) on OLCF machines. A work-in-progress spack package is being developed that will install the pre-requisite openblas and armadillo libraries.

This commit is intended to be a starting point for a refined top-level CMakeLists.txt and has much room for improvement, particularly in setting options at the top-level to configure the subdirectory builds. I leave it up to the primary developers to decide how best to implement a top-level CMakeLists.txt to meet their needs.

This commit:
- Adds a top-level `CMakeLists.txt` so all sub-components can be built using a single `cmake` invocation. 

- Adds `install` instructions to the sub-directory targets to allow installation of the package at a specific directory using `-DCMAKE_INSTALL_PREFIX`. This eliminates the need for `cp` statements as used in the example `build.sh`.

The package can now be built like (assuming dependencies are in the environment where CMake can find them):

```sh
git clone https://github.com/ramkikannan/planc
mkdir planc/my_build && cd $_
# on, say, summit.olcf.ornl.gov: module load gcc openblas armadillo cuda
cmake -DCMAKE_INSTALL_PREFIX=/sw/.testing/belhorn/planc_test \
      -DCMAKE_IGNORE_MKL=1
      -DCMAKE_BUILD_CUDA=1 ../
make
make install
```